### PR TITLE
Add button to quickly add BrushForms to a Brush Node

### DIFF
--- a/addons/GodotNode2Tile/main_script.gd
+++ b/addons/GodotNode2Tile/main_script.gd
@@ -1,6 +1,9 @@
 @tool
 extends EditorPlugin
 
+const INSPECTOR_SCRIPT:GDScript = preload("res://addons/GodotNode2Tile/src/inspector_plugin.gd")
+var inspector_plugin:EditorInspectorPlugin = INSPECTOR_SCRIPT.new()
+
 
 func _enter_tree():
 	add_custom_type("Brush",
@@ -17,9 +20,12 @@ func _enter_tree():
 		"VertexAttachment",
 		preload("../GodotNode2Tile/src/cl_vertex_attachment.gd"),
 		preload("../GodotNode2Tile/misc/icon_vatt.png"))
+	
+	add_inspector_plugin(inspector_plugin)
 
 
 func _exit_tree():
 	remove_custom_type("Brush")
 	remove_custom_type("BrushForm")
 	remove_custom_type("VertexAttachment")
+	remove_inspector_plugin(inspector_plugin)

--- a/addons/GodotNode2Tile/src/cl_form.gd
+++ b/addons/GodotNode2Tile/src/cl_form.gd
@@ -1,6 +1,7 @@
 @tool
 class_name BrushForm extends Node3D
 
+
 @export_subgroup("data")
 @export var positions : Array[Vector3]
 @export var normals : Array[Vector3]

--- a/addons/GodotNode2Tile/src/inspector_plugin.gd
+++ b/addons/GodotNode2Tile/src/inspector_plugin.gd
@@ -1,0 +1,20 @@
+extends EditorInspectorPlugin
+
+
+func _can_handle(object: Object) -> bool:
+	return object is Brush
+
+
+func _parse_begin(object: Object) -> void:
+	if object is Brush:
+		var new_button:Button = Button.new()
+		new_button.text = "Add BrushForm"
+		new_button.tooltip_text = "Adds a BrushForm as a child of the Brush"
+		add_custom_control(new_button)
+		new_button.pressed.connect(
+		func():
+			var new_brush_form:BrushForm = BrushForm.new()
+			new_brush_form.name = "BrushForm"
+			object.add_child(new_brush_form, true)
+			new_brush_form.set_owner(object.get_tree().edited_scene_root)
+			)


### PR DESCRIPTION
These changes add a button to the Brush Node which allows for quickly and easily adding a new BrushForm to the Brush Node. How this looks can be seen here:
![graphic](https://github.com/user-attachments/assets/7b206ce4-0f61-4ceb-b457-92ec4004e1c9)
